### PR TITLE
Update Nucleus: Interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # Nucleus: Interpreter
 
-Nucleus: Interpreter is an interpreter for scripting languages and an execution environment for C programs fulfilling
-certain requirements. Its primary purpose is that of a the execution environment. Such C programs attain      several
-features in usually not provided by in plain C programs which (among others) are:
+Nucleus: Interpreter is a C cross-platform interpreter/execution environment for Windows, Linux, and OS X.
+Nucleus is made available publicly under the
+[MIT license](https://github.com/primordialmachine/nucleus-interpreter/blob/master/LICENSE.md)
+on
+[Github](https://github.com/primordialmachine/nucleus-interpreter).
 
+Its current features encompass
 - implicit memory management functionality through garbage collection
-- advanced error raising and handling functionality
+- advanced error raising and handling functionality.
+
+Nucleus: Interpreter depends on [Nucleus](https://github.com/primordialmachine/nucleus).
+
 
 ## Building under Windows/Visual Studio
 Visual Studio is currently *still* supported.
@@ -35,6 +41,18 @@ ctest -C <configuration>
 
 ```configuration``` is one of `Debug`, `Release`, `MinSizeRel`, `RelWithDebInfo`.
 
+### Compilation options (Visual Studio)
+
+#### `With-Static-Runtime`
+For Visual Studio builds, the option `With-Static-Runtime=(ON|OFF)` is supported.
+`ON` enables static linking with the C runtime, `OFF` enables dynamic linking with the runtime.
+The default value is `ON`.
+
+For example, to enable dynamic linking with the runtime enter
+```
+cmake -DWith-Static-Runtime=OFF CMakeLists.txt
+```
+
 ## Building und Linux and Cygwin
 Open the console.
 
@@ -57,6 +75,9 @@ To execute the unit tests, enter
 ctest
 ```
 
+You can find the build products under `products/<platform>/(bin|lib)`
+where `<platform>` is one of `x86` or `x64`.
+
 ### Compilation options (Linux and Cygwin)
 For Linux and Cygwin builds, certain CMake options are supported.
 The currently supported options are `With-Debug-Information=(ON|OFF)`
@@ -66,6 +87,32 @@ For example, to enable both optimizations and debug information enter
 ```
 cmake -DWith-Optimizations=ON -DWith-Debug-Information=ON CMakeLists.txt
 ```
+
+## Out of source builds
+The above build instruction for
+Visual Studio 2017/Windows,
+GCC/Linux, and
+GCC/Cygwin
+use CMake to generate project files for in-source builds.
+However, it is recommended to use CMake to generate project files for out-of-source builds.
+
+To generate project files for an out-of-source build,
+simple enter some directory (which should be empty).
+This directory is called the build directory.
+In that directory enter the CMake command with options and generators to your liking as described above.
+However, instead of writing `CMakeLists.txt` in the end, enter the path to the CMakeLists.txt file of
+Nucleus - relative to your build directory.
+
+For example, if you are in the source directory and you want the project files for Visual Studio to be generated
+in `./build/visualstudio`, then simply enter `mkdir build; cd build; mkdir visualstudio`. Then tell CMake to
+generate the build files in there by invokin
+
+```
+cmake -G "Visual Studio 15 2017 Win64" . ./../../CMakeLists.txt
+```
+
+## Documentation
+The documentation of Nucleus: Interpreter is not yet publicly available.
 
 #### Continuous Integrations Status Maxtrix
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -14,8 +14,6 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # The interpreter types file.
 set(SOURCE_FILENAME "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Types.l")
 
@@ -31,9 +29,9 @@ add_custom_command(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag.h"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag.c"
     DEPENDS
-        ${SOURCE_FILENAME} Nucleus.Interpreter.Tools.Generator
+        ${SOURCE_FILENAME} Interpreter.Tools.Generator
     COMMAND
-        Nucleus.Interpreter.Tools.Generator --generator=${TAG_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag"
+        Interpreter.Tools.Generator --generator=${TAG_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag"
     COMMENT
         "Generating ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag.c and ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Tag.h from ${SOURCE_FILENAME}"
     VERBATIM
@@ -51,9 +49,9 @@ add_custom_command(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value.h"
     DEPENDS
-        ${SOURCE_FILENAME} Nucleus.Interpreter.Tools.Generator
+        ${SOURCE_FILENAME} Interpreter.Tools.Generator
     COMMAND
-        Nucleus.Interpreter.Tools.Generator --generator=${VALUE_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value"
+        Interpreter.Tools.Generator --generator=${VALUE_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value"
     COMMENT
         "Generating ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value.c and ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/Value.h from ${SOURCE_FILENAME}"
     VERBATIM
@@ -71,9 +69,9 @@ add_custom_command(
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue.c"
         "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue.h"
     DEPENDS
-        ${SOURCE_FILENAME} Nucleus.Interpreter.Tools.Generator
+        ${SOURCE_FILENAME} Interpreter.Tools.Generator
     COMMAND
-        Nucleus.Interpreter.Tools.Generator --generator=${TAGGEDVALUE_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue"
+        Interpreter.Tools.Generator --generator=${TAGGEDVALUE_GENERATOR} --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} "${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue"
     COMMENT
         "Generating ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue.c and ${CMAKE_CURRENT_SOURCE_DIR}/src/Nucleus/Interpreter/TaggedValue.h from ${SOURCE_FILENAME}"
     VERBATIM
@@ -91,9 +89,9 @@ add_custom_command(
     OUTPUT
         ${TARGET_HEADER_FILENAME}
     DEPENDS
-        ${SOURCE_FILENAME} Nucleus.Interpreter.Tools.Unicode
+        ${SOURCE_FILENAME} Interpreter.Tools.Unicode
     COMMAND
-        Nucleus.Interpreter.Tools.Unicode --generator=Header --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} ${TARGET_HEADER_FILENAME}
+        Interpreter.Tools.Unicode --generator=Header --prefix=Nucleus_Interpreter_ ${SOURCE_FILENAME} ${TARGET_HEADER_FILENAME}
     COMMENT
         "Generating ${TARGET_HEADER_FILENAME} from ${SOURCE_FILENAME}"
     VERBATIM
@@ -108,9 +106,9 @@ add_custom_command(
     OUTPUT
         ${TARGET_INLAY_FILENAME}
     DEPENDS
-        ${SOURCE_FILENAME} Nucleus.Interpreter.Tools.Unicode
+        ${SOURCE_FILENAME} Interpreter.Tools.Unicode
     COMMAND
-        Nucleus.Interpreter.Tools.Unicode --generator=Inlay --prefix= ${SOURCE_FILENAME} ${TARGET_INLAY_FILENAME}
+        Interpreter.Tools.Unicode --generator=Inlay --prefix= ${SOURCE_FILENAME} ${TARGET_INLAY_FILENAME}
     COMMENT
         "Generating ${TARGET_INLAY_FILENAME} from ${SOURCE_FILENAME}"
     VERBATIM
@@ -131,7 +129,8 @@ add_library(Nucleus.Interpreter.Library STATIC ${SOURCE_FILES} ${HEADER_FILES})
 target_link_libraries(Nucleus.Interpreter.Library Nucleus.Library)
 target_include_directories(Nucleus.Interpreter.Library PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
 target_include_directories(Nucleus.Interpreter.Library INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
-
+# Set its properties.
+set_project_default_properties(Nucleus.Interpreter.Library)
 
 IF(DOXYGEN_FOUND)
     ADD_CUSTOM_TARGET(Nucleus.Interpreter.Library.Documentation ${DOXYGEN_EXECUTABLE} COMMENT "Building documentation")

--- a/library/src/Nucleus/Interpreter/Context.c
+++ b/library/src/Nucleus/Interpreter/Context.c
@@ -127,10 +127,10 @@ Nucleus_Interpreter_Context_allocateObject
 {
     Nucleus_Status status;
     Nucleus_Interpreter_GC_Tag *tag;
-    status = Nucleus_Interpreter_GC_allocateManaged(&NUCLEUS_INTERPRETER_PROCESSCONTEXT(context)->gc,
-                                                    &tag,
-                                                    numberOfBytes,
-                                                    &context->generalHeap.objects);
+    status = Nucleus_Interpreter_GC_allocateManagedNoError(&NUCLEUS_INTERPRETER_PROCESSCONTEXT(context)->gc,
+                                                           &tag,
+                                                           numberOfBytes,
+                                                           &context->generalHeap.objects);
     if (status)
     {
         Nucleus_Interpreter_ProcessContext_setStatus(NUCLEUS_INTERPRETER_PROCESSCONTEXT(context), status);

--- a/library/src/Nucleus/Interpreter/GC/Object.c
+++ b/library/src/Nucleus/Interpreter/GC/Object.c
@@ -122,7 +122,7 @@ Nucleus_Interpreter_GC_Tag_setWhite
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 Nucleus_Interpreter_NonNull() Nucleus_Interpreter_Status
-Nucleus_Interpreter_GC_allocateManaged
+Nucleus_Interpreter_GC_allocateManagedNoError
     (
         Nucleus_Interpreter_GC *gc,
         Nucleus_Interpreter_GC_Tag **tag,
@@ -150,7 +150,7 @@ Nucleus_Interpreter_GC_allocateManaged
 }
 
 Nucleus_Interpreter_NonNull() Nucleus_Interpreter_Status
-Nucleus_Interpreter_GC_allocateManagedArray
+Nucleus_Interpreter_GC_allocateManagedArrayNoError
     (
         Nucleus_Interpreter_GC *gc,
         Nucleus_Interpreter_GC_Tag **tag,
@@ -177,7 +177,7 @@ Nucleus_Interpreter_GC_allocateManagedArray
     }
     // Compute the array size in Bytes.
     Nucleus_Size arraySizeInBytes;
-    nucleusStatus = Nucleus_safeMul(elementSizeInBytes, numberOfElements, &arraySizeInBytes);
+    nucleusStatus = Nucleus_safeMulSize(elementSizeInBytes, numberOfElements, &arraySizeInBytes);
     if (nucleusStatus) 
     {
         switch (nucleusStatus)
@@ -190,7 +190,7 @@ Nucleus_Interpreter_GC_allocateManagedArray
     };
     // Compute the allocation size in Bytes.
     Nucleus_Size sizeInBytes;
-    nucleusStatus = Nucleus_safeAdd(tagSizeInBytes, arraySizeInBytes, &sizeInBytes);
+    nucleusStatus = Nucleus_safeAddSize(tagSizeInBytes, arraySizeInBytes, &sizeInBytes);
     if (Nucleus_Unlikely(nucleusStatus)) 
     {
         switch (nucleusStatus)

--- a/library/src/Nucleus/Interpreter/GC/Object.h
+++ b/library/src/Nucleus/Interpreter/GC/Object.h
@@ -172,7 +172,7 @@ Nucleus_Interpreter_GC_Tag_setWhite
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
 Nucleus_Interpreter_NonNull() Nucleus_Interpreter_Status
-Nucleus_Interpreter_GC_allocateManaged
+Nucleus_Interpreter_GC_allocateManagedNoError
     (
         Nucleus_Interpreter_GC *gc,
         Nucleus_Interpreter_GC_Tag **tag,
@@ -181,7 +181,7 @@ Nucleus_Interpreter_GC_allocateManaged
     );
 
 Nucleus_Interpreter_NonNull() Nucleus_Interpreter_Status
-Nucleus_Interpreter_GC_allocateManagedArray
+Nucleus_Interpreter_GC_allocateManagedArrayNoError
     (
         Nucleus_Interpreter_GC *gc,
         Nucleus_Interpreter_GC_Tag **tag,

--- a/library/src/Nucleus/Interpreter/String.h
+++ b/library/src/Nucleus/Interpreter/String.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include "Nucleus/Interpreter/Annotations.h"
-#include <stdbool.h> /// @todo for bool. Remove this.
-#include <stddef.h> /// @todo For size_t. Remove this.
+#include "Nucleus/Types/Boolean.h"
+#include "Nucleus/Types/Size.h"
 
 // Forward declaration.
 typedef struct Nucleus_Interpreter_Context Nucleus_Interpreter_Context;
@@ -32,10 +32,10 @@ Nucleus_Interpreter_String_create
     (
         Nucleus_Interpreter_Context *context,
         const char *bytes,
-        size_t numberOfBytes
+        Nucleus_Size numberOfBytes
     );
 
-Nucleus_Interpreter_NonNull() bool
+Nucleus_Interpreter_NonNull() Nucleus_Boolean
 Nucleus_Interpreter_String_equalTo
     (
         Nucleus_Interpreter_Context *context,
@@ -56,7 +56,7 @@ Nucleus_Interpreter_String_concatenate
 /// @param string a pointer to an @a Nucleus_Interpreter_String object
 /// @return the number of Bytes of the atom
 /// @failure @a *status is assigned a status code denoting the reason for the failure, then @a longjmp(*environment, -1) is invoked
-Nucleus_Interpreter_NonNull() size_t
+Nucleus_Interpreter_NonNull() Nucleus_Size
 Nucleus_Interpreter_String_getNumberOfBytes
     (
         Nucleus_Interpreter_Context *context,

--- a/test/Context/CMakeLists.txt
+++ b/test/Context/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.Context C)
-message("building Nucleus.Interpreter.Test.Context")
+set(PROJECT_NAME "Interpreter.Test.Context")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.Context ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.Context Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.Context COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.Context>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/ScratchSpace/CMakeLists.txt
+++ b/test/ScratchSpace/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.ScratchSpace C)
-message("building Nucleus.Interpreter.Test.ScratchSpace")
+set(PROJECT_NAME "Interpreter.Test.ScratchSpace")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.ScratchSpace ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.ScratchSpace Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.ScratchSpace COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.ScratchSpace>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/String/CMakeLists.txt
+++ b/test/String/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.String C)
-message("building Nucleus.Interpreter.Test.String")
+set(PROJECT_NAME "Interpreter.Test.String")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.String ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.String Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.String COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.String>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/StringBuffer/CMakeLists.txt
+++ b/test/StringBuffer/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.StringBuffer C)
-message("building Nucleus.Interpreter.Test.StringBuffer")
+set(PROJECT_NAME "Interpreter.Test.StringBuffer")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.StringBuffer ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.StringBuffer Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.StringBuffer COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.StringBuffer>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/StringIterator/CMakeLists.txt
+++ b/test/StringIterator/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.StringIterator C)
-message("building Nucleus.Interpreter.Test.StringIterator")
+set(PROJECT_NAME "Interpreter.Test.StringIterator")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.StringIterator ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.StringIterator Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.StringIterator COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.StringIterator>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/getFileContents/CMakeLists.txt
+++ b/test/getFileContents/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.getFileContents C)
-message("building Nucleus.Interpreter.Test.getFileContents")
+set(PROJECT_NAME "Interpreter.Test.getFileContents")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.getFileContents ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.getFileContents Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.getFileContents COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.getFileContents>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/setFileContents/CMakeLists.txt
+++ b/test/setFileContents/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.setFileContents C)
-message("building Nucleus.Interpreter.Test.setFileContents")
+set(PROJECT_NAME "Interpreter.Test.setFileContents")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.setFileContents ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.setFileContents Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.setFileContents COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.setFileContents>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/test/stringToInteger/CMakeLists.txt
+++ b/test/stringToInteger/CMakeLists.txt
@@ -1,12 +1,12 @@
-# @author Michael Heilmann
-# @copyright Copyright (c) Michael Heilmann 2017
+# Copyright (c) Michael Heilmann 2017, 2018
 
 # Minimum required CMake version.
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Test.stringToInteger C)
-message("building Nucleus.Interpreter.Test.stringToInteger")
+set(PROJECT_NAME "Interpreter.Test.stringToInteger")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -16,17 +16,17 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
 
-set_project_default_properties()
-
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
 # Find and configure header files.
 file(GLOB_RECURSE HEADER_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.h")
 set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Test.stringToInteger ${SOURCE_FILES} ${HEADER_FILES})
-target_link_libraries(Nucleus.Interpreter.Test.stringToInteger Nucleus.Interpreter.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES})
+target_link_libraries(${PROJECT_NAME} Nucleus.Interpreter.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})
 
 # Test.
-add_test(NAME Nucleus.Interpreter.Test.stringToInteger COMMAND $<TARGET_FILE:Nucleus.Interpreter.Test.stringToInteger>
+add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})

--- a/tools/Generator/CMakeLists.txt
+++ b/tools/Generator/CMakeLists.txt
@@ -4,8 +4,9 @@
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Tools.Generator C)
-message("building Nucleus.Interpreter.Tools.Generator")
+set(PROJECT_NAME "Interpreter.Tools.Generator")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -14,8 +15,6 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/detect_compiler_and_platform.cmake)
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
-
-set_project_default_properties()
 
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
@@ -26,6 +25,8 @@ set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 file(GLOB_RECURSE INLAY_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.i")
 set_source_files_properties(${INLAY_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Tools.Generator ${SOURCE_FILES} ${HEADER_FILES} ${INLAY_FILES})
-target_include_directories(Nucleus.Interpreter.Tools.Generator PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
-target_link_libraries(Nucleus.Interpreter.Tools.Generator Nucleus.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES} ${INLAY_FILES})
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+target_link_libraries(${PROJECT_NAME} Nucleus.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})

--- a/tools/Unicode/CMakeLists.txt
+++ b/tools/Unicode/CMakeLists.txt
@@ -1,12 +1,12 @@
-# @author Michael Heilmann
-# @copyright Copyright (c) Michael Heilmann 2017
+# Copyright (c) Michael Heilmann 2017, 2018
 
 # Minimum required CMake version.
 cmake_minimum_required (VERSION 3.8)
 
 # Project.
-project(Nucleus.Interpreter.Tools.Unicode C)
-message("building Nucleus.Interpreter.Tools.Unicode")
+set(PROJECT_NAME "Interpreter.Tools.Unicode")
+project(${PROJECT_NAME} C)
+message("building ${PROJECT_NAME}")
 
 if (NUCLEUS_PATH)
   include(${NUCLEUS_PATH}/buildsystem/detect_compiler_and_platform.cmake)
@@ -15,8 +15,6 @@ else()
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/detect_compiler_and_platform.cmake)
   include(${CMAKE_CURRENT_SOURCE_DIR}/../buildsystem/set_default_project_properties.cmake)
 endif()
-
-set_project_default_properties()
 
 # Find and configure source files.
 file(GLOB_RECURSE SOURCE_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.c")
@@ -27,6 +25,8 @@ set_source_files_properties(${HEADER_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 file(GLOB_RECURSE INLAY_FILES RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "src/*.i")
 set_source_files_properties(${INLAY_FILES} PROPERTIES HEADER_FILE_ONLY TRUE)
 # Add and configure executable.
-add_executable(Nucleus.Interpreter.Tools.Unicode ${SOURCE_FILES} ${HEADER_FILES} ${INLAY_FILES})
-target_include_directories(Nucleus.Interpreter.Tools.Unicode PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
-target_link_libraries(Nucleus.Interpreter.Tools.Unicode Nucleus.Library)
+add_executable(${PROJECT_NAME} ${SOURCE_FILES} ${HEADER_FILES} ${INLAY_FILES})
+target_include_directories(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src")
+target_link_libraries(${PROJECT_NAME} Nucleus.Library)
+# Set its properties.
+set_project_default_properties(${PROJECT_NAME})


### PR DESCRIPTION
- Cleanup.
- Update copyright notices in file headers.
- Update for latest version of Nucleus.
- Update README.md.
- build system: Work-around filename/pathname length restriction imposed on
  CMake by Windows/Visual Studio 2017.